### PR TITLE
#25 - Add compatibility analysers

### DIFF
--- a/src/Evelyn.Core.Tests/Evelyn.Core.Tests.csproj
+++ b/src/Evelyn.Core.Tests/Evelyn.Core.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="NSubstitute" Version="3.0.1" />

--- a/src/Evelyn.Core/Evelyn.Core.csproj
+++ b/src/Evelyn.Core/Evelyn.Core.csproj
@@ -14,6 +14,9 @@
   
   <ItemGroup>
     <PackageReference Include="CqrsLite" Version="0.17.0" />
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Will flag up any issues if we use obsolete APIs or APIs that are not supported by some platforms. See https://blogs.msdn.microsoft.com/dotnet/2017/10/31/introducing-api-analyzer/ for more info