### PR TITLE
Switch to portable PDBs

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 ﻿#tool "nuget:?package=GitVersion.CommandLine"
-#tool "nuget:?package=OpenCover"
+#tool "nuget:?package=OpenCover&version=4.6.832"
 #tool "nuget:?package=ReportGenerator"
 #tool "nuget:?package=GitReleaseNotes"
 #addin "nuget:?package=Cake.DoInDirectory"

--- a/cake.config
+++ b/cake.config
@@ -1,0 +1,4 @@
+; The configuration file for Cake.
+
+[Nuget]
+Source=https://www.myget.org/F/binarymash-unstable/api/v2;https://api.nuget.org/v3/index.json

--- a/src/Evelyn.Client.Host/Evelyn.Client.Host.csproj
+++ b/src/Evelyn.Client.Host/Evelyn.Client.Host.csproj
@@ -12,13 +12,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Client.Rest/Evelyn.Client.Rest.csproj
+++ b/src/Evelyn.Client.Rest/Evelyn.Client.Rest.csproj
@@ -17,13 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Client/Evelyn.Client.csproj
+++ b/src/Evelyn.Client/Evelyn.Client.csproj
@@ -18,13 +18,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Core/Evelyn.Core.csproj
+++ b/src/Evelyn.Core/Evelyn.Core.csproj
@@ -17,13 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Management.Api.Rest/Evelyn.Management.Api.Rest.csproj
+++ b/src/Evelyn.Management.Api.Rest/Evelyn.Management.Api.Rest.csproj
@@ -17,13 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Server.Host/Evelyn.Server.Host.csproj
+++ b/src/Evelyn.Server.Host/Evelyn.Server.Host.csproj
@@ -9,13 +9,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Evelyn.Storage.EventStore/Evelyn.Storage.EventStore.csproj
+++ b/src/Evelyn.Storage.EventStore/Evelyn.Storage.EventStore.csproj
@@ -17,13 +17,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-xPlatform|AnyCPU'">
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.25.0" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
Requires a a beta version of OpenCover, as current release doesn't support it. Uploaded this to myget feed, but seems I then had to upgrade Cake to 0.30 in order to support multiple nuget sources. Which now results in build warnings. grrr.